### PR TITLE
Arrumar banco de dados

### DIFF
--- a/docker/init.sql
+++ b/docker/init.sql
@@ -1,13 +1,3 @@
-CREATE USER planteiAdmin WITH ENCRYPTED PASSWORD 'planteiAdmin';
-
-CREATE DATABASE plantei WITH
-        OWNER = planteiAdmin
-        ENCODING = 'UTF8'
-        TABLESPACE = pg_default
-        CONNECTION LIMIT = -1;
-
-GRANT ALL PRIVILEGES ON DATABASE plantei TO planteiAdmin;
-
 create table Usuario(
 	ID_usuario serial primary key,
 	nome varchar(50) not null,


### PR DESCRIPTION
# Banco de dados

As primeiras linhas do banco de dados estavam dando conflito, não tinha percebido :(

> CREATE DATABASE plantei WITH
        OWNER = planteiAdmin
        ENCODING = 'UTF8'
        TABLESPACE = pg_default
        CONNECTION LIMIT = -1;

Quando não existe um banco de dados a imagem do docker `postgres` cria um banco de dados automaticamente, o nome do banco de dados é passado pela variável de ambiente.

> CREATE USER planteiAdmin WITH ENCRYPTED PASSWORD 'planteiAdmin';
        GRANT ALL PRIVILEGES ON DATABASE plantei TO planteiAdmin;

O usuário `planteiAdmin` também é criado como superuser e a senha é settada com as variáveis de ambiente.